### PR TITLE
No test if CoinToss could afford to pay a winning bet

### DIFF
--- a/contracts/CoinToss.sol
+++ b/contracts/CoinToss.sol
@@ -15,11 +15,11 @@ contract CoinToss
         uint amount;
     }
 
-    uint public constant MAXIMUM_BET_SIZE = 1e18;
     uint public constant MAXIMUM_PASSED_BLOCKS = 255;
     uint public constant MINIMUM_PASSED_BLOCKS = 5;
     uint public bankroll = 0;
     uint public counter = 0;
+    uint public maximumBetSize = 0;
 
     mapping(uint => Toss) public coinTosses;
 
@@ -35,10 +35,14 @@ contract CoinToss
 
     function placeBet (bool betIsHeads) public payable
     {
-        require(msg.value <= MAXIMUM_BET_SIZE, "Bet is too big");
+        require(msg.value <= maximumBetSize, "Bet is too big");
 
-        coinTosses[counter] =
-            Toss(msg.sender, block.number + MINIMUM_PASSED_BLOCKS, betIsHeads, msg.value);
+        coinTosses[counter] = Toss(
+            msg.sender,
+            block.number + MINIMUM_PASSED_BLOCKS,
+            betIsHeads,
+            msg.value
+        );
 
         emit betPlaced(counter, msg.sender, betIsHeads, msg.value);
 
@@ -79,24 +83,24 @@ contract CoinToss
         }
 
         emit CoinTossed(betId, isHeads);
-
-
         delete coinTosses[betId];
     }
 
     function fund () payable public
     {
         bankroll += msg.value;
+        maximumBetSize = bankroll / 2;
     }
 
     function () payable public
     {
         bankroll += msg.value;
+        maximumBetSize = bankroll / 2;
     }
 
     function kill () public
     {
-        require (msg.sender == owner);
+        require (msg.sender == owner, "You are not the contract owner");
         selfdestruct(owner);
     }
 }

--- a/test/TestCoinToss.js
+++ b/test/TestCoinToss.js
@@ -46,11 +46,20 @@ contract('testing CoinToss contract', async (accounts) => {
         assert.equal(count, 1);
     });
 
-    it('should reject a bet above the MAXIMUM_BET_SIZE', async () => {
+    it('should reject a bet above the maximumBetSize', async () => {
         const coinToss = await CoinToss.deployed();
-        const maxBet = await coinToss.MAXIMUM_BET_SIZE.call();
+        const maxBet = await coinToss.maximumBetSize.call();
         const amountToBet = maxBet * 2;
         const placeBet = coinToss.placeBet(userBet, { from: accounts[1], value: amountToBet });
+
+        await expectThrow(placeBet);
+    });
+
+    it('should reject a bet it cannot afford to pay out', async () => {
+        const coinToss = await CoinToss.deployed();
+        const bankroll = await coinToss.bankroll.call();
+        const tooBigBet = (bankroll / 2) + 10;
+        const placeBet = coinToss.placeBet(userBet, { from: accounts[1], value: tooBigBet });
 
         await expectThrow(placeBet);
     });


### PR DESCRIPTION
There was no test to determine if the contract could afford to pay out a winning bet.  It would accept a bet even if the bankroll was empty.